### PR TITLE
fix minor formatting issue

### DIFF
--- a/src/install.sql
+++ b/src/install.sql
@@ -170,13 +170,13 @@ BEGIN
   a := array_length(numbers, 1);
   --raise notice 'Offset start: %', a;
   FOR i IN 0..(array_length(numbers, 1) - 1) LOOP
-    v:= numbers[i + 1];
+    v := numbers[i + 1];
     --raise notice 'avi: % % %', a, v, i;
     m := v % array_length(arr_alphabet, 1);
     --raise notice 'm: %', m;
     char :=  ascii(arr_alphabet[m + 1]);
     --raise notice 'char: %', char;
-    a:= char + i + a;
+    a := char + i + a;
     --raise notice 'a: %', a;
   END LOOP;
   offset_var := a % array_length(arr_alphabet, 1);


### PR DESCRIPTION
For some reason dbmate (which uses lib pq) didn't like the output after formatting, without adding these spaces.