### PR TITLE
mark functions as immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 
 ## V0.2
 -Added spec tests & fixed any failures
+
+## V0.2.1
+-Marked functions as immutable

--- a/src/install.sql
+++ b/src/install.sql
@@ -31,7 +31,7 @@ BEGIN
   --raise notice 'Shuffled alphabet: %', array_to_string(chars, '');
   RETURN array_to_string(chars, '');
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.checkAlphabet(alphabet TEXT) RETURNS BOOLEAN AS $$
 DECLARE
@@ -58,7 +58,7 @@ BEGIN
 
   RETURN TRUE;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.isBlockedId(id TEXT) RETURNS BOOLEAN AS $$
 DECLARE
@@ -112,7 +112,7 @@ BEGIN
   --raise notice 'toId result: %', array_to_string(id, '');
   RETURN array_to_string(id, '');
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.toNumber(id TEXT, alphabet TEXT) RETURNS BIGINT AS $$
 DECLARE
@@ -139,7 +139,7 @@ BEGIN
   --raise notice 'tonumber result: %', result;
   RETURN result;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.encodeNumbers(numbers BIGINT[], alphabet TEXT, minLength INT, increment INT DEFAULT 0) RETURNS TEXT AS $$
 DECLARE
@@ -231,7 +231,7 @@ BEGIN
 
   RETURN id;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 
 CREATE OR REPLACE FUNCTION sqids.decode(id TEXT, alphabet TEXT DEFAULT 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') RETURNS BIGINT[] AS $$
@@ -301,7 +301,7 @@ BEGIN
 
   RETURN ret;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.encode(numbers BIGINT[], alphabet TEXT DEFAULT 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', minLength INT DEFAULT 0) RETURNS TEXT AS $$
 DECLARE
@@ -313,13 +313,13 @@ BEGIN
   id := sqids.encodeNumbers(numbers, alphabet, minLength);
   RETURN id;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.encode(numbers BIGINT[], minLength INT) RETURNS TEXT AS $$
 BEGIN
   RETURN sqids.encode(numbers, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', minLength);
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sqids.defaultBlocklist() RETURNS VOID AS $$
 BEGIN


### PR DESCRIPTION
When using the output of `squids.encode(...)`in a `GENERATED` column, postgres was complaining that the functions needs to be immutable. 

```plpgsql
-- Example Table
CREATE TABLE public.order(
  id integer PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
  external_id text UNIQUE NOT NULL GENERATED ALWAYS AS (sqids.encode(ARRAY[id, 0], 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', 5)) STORED,
  amount numeric NOT NULL,
  name text,
  created_at timestamp with time zone DEFAULT timezone('utc', now()) NOT NULL,
  updated_at timestamp with time zone DEFAULT timezone('utc', now()) NOT NULL
);
```

From the [postgres documentation](https://www.postgresql.org/docs/current/xfunc-volatility.html#XFUNC-VOLATILITY):

> An IMMUTABLE function cannot modify the database and is guaranteed to return the same results given the same arguments forever. This category allows the optimizer to pre-evaluate the function when a query calls it with constant arguments. For example, a query like SELECT ... WHERE x = 2 + 2 can be simplified on sight to SELECT ... WHERE x = 4, because the function underlying the integer addition operator is marked IMMUTABLE.

TL;DR Functions marked as IMMUTABLE always return the same output for the same input and do not depend on any external state. Non-IMMUTABLE functions may depend on database state or have side effects.

Accordingly, I've marked the following functions as follows:

| Function | IMMUTABLE |
|----------|-----------|
| `sqids.shuffle` | Yes |
| `sqids.checkAlphabet` | Yes |
| `sqids.toId` | Yes |
| `sqids.toNumber` | Yes |
| `sqids.encodeNumbers` | Yes |
| `sqids.decode` | Yes |
| `sqids.encode` (both versions) | Yes |
| `sqids.isBlockedId` | No |
| `sqids.defaultBlocklist` | No |


The tests included with the repo all pass locally on my machine with these changes.
